### PR TITLE
intro-comparch/rotations: Change rotations parameter type

### DIFF
--- a/chapters/intro-computer-architecture/binary-hex/drills/tasks/rotations/solution/rotations.c
+++ b/chapters/intro-computer-architecture/binary-hex/drills/tasks/rotations/solution/rotations.c
@@ -2,7 +2,7 @@
 
 #include <stdio.h>
 
-void rotate_left(int *number, int bits)
+void rotate_left(unsigned int *number, int bits)
 {
 	unsigned int bit_mask = -1;
 
@@ -13,7 +13,7 @@ void rotate_left(int *number, int bits)
 	(*number) |= bit_mask;
 }
 
-void rotate_right(int *number, int bits)
+void rotate_right(unsigned int *number, int bits)
 {
 	unsigned int bit_mask = -1;
 
@@ -26,7 +26,7 @@ void rotate_right(int *number, int bits)
 
 int main(void)
 {
-	int number;
+	unsigned int number;
 
 	number = 0x80000000;
 	rotate_left(&number, 1);

--- a/chapters/intro-computer-architecture/binary-hex/drills/tasks/rotations/support/rotations.c
+++ b/chapters/intro-computer-architecture/binary-hex/drills/tasks/rotations/support/rotations.c
@@ -2,14 +2,14 @@
 
 #include <stdio.h>
 
-void rotate_left(int *number, int bits)
+void rotate_left(unsigned int *number, int bits)
 {
 	/* TODO */
 	(void) number;
 	(void) bits;
 }
 
-void rotate_right(int *number, int bits)
+void rotate_right(unsigned int *number, int bits)
 {
 	/* TODO */
 	(void) number;


### PR DESCRIPTION
Functions of the rotation task accepted `int` parameters, which can lead to unexpected behavior with bit operators. For more details, see systems-cs-pub-ro/iocla#171.

# Prerequisite Checklist

<!--
Please mark items appropriately:
-->

- [x] Read the [contribution guidelines](https://github.com/open-education-hub/ccas-internal/blob/main/CONTRIBUTING.md#pull-requests) regarding submitting new changes to the project;
- [x] Tested your changes against relevant architectures and platforms;
- [x] Updated relevant documentation (if needed).

## Description of changes

This PR updates the types of rotation functions' parameters and solution to use `unsigned int` instead of `int` (wherever the signedness is relevant).
