### PR TITLE
memory-layout/memory-operations: Parenthesize GET_PIXEL macro

### DIFF
--- a/chapters/memory-layout/memory-operations/drills/tasks/pixels/README.md
+++ b/chapters/memory-layout/memory-operations/drills/tasks/pixels/README.md
@@ -36,7 +36,7 @@ p.b = 0.11 * p.b;
 > **Hint:** For simplicity, you can use the following macro:
 >
 > ```c
-> #define GET_PIXEL(a, i ,j) (*(*(a + i) + j))
+> #define GET_PIXEL(a, i ,j) (*(*((a) + (i)) + (j)))
 > ```
 
 If you're having difficulties solving this exercise, go through [this](../../../reading/README.md#structures-and-pointers-to-structures) reading material.

--- a/chapters/memory-layout/memory-operations/drills/tasks/pixels/solution/pixels.c
+++ b/chapters/memory-layout/memory-operations/drills/tasks/pixels/solution/pixels.c
@@ -7,7 +7,7 @@
 #include <time.h>
 #include "pixel.h"
 
-#define GET_PIXEL(a, i, j) (*(*(a + i) + j))
+#define GET_PIXEL(a, i, j) (*(*((a) + (i)) + (j)))
 
 void color_to_gray(struct picture *pic)
 {


### PR DESCRIPTION
This commit adds parentheses around function-like macro parameters. For more details, see systems-cs-pub-ro/iocla#172.

# Prerequisite Checklist

<!--
Please mark items appropriately:
-->

- [x] Read the [contribution guidelines](https://github.com/open-education-hub/ccas-internal/blob/main/CONTRIBUTING.md#pull-requests) regarding submitting new changes to the project;
- [x] Tested your changes against relevant architectures and platforms;
- [x] Updated relevant documentation (if needed).
