### PR TITLE
memory-layout/memory-operations: Fix swapRows call in pixels solution

### DIFF
--- a/chapters/memory-layout/memory-operations/drills/tasks/pixels/solution/pixels.c
+++ b/chapters/memory-layout/memory-operations/drills/tasks/pixels/solution/pixels.c
@@ -34,7 +34,7 @@ void reverse_pic(struct picture *pic)
 {
 	for (int i = 0; i < pic->height / 2; ++i)
 		swap_rows(pic->pix_array[i], pic->pix_array[pic->height - 1 - i],
-				pic->height);
+				pic->width);
 }
 
 int main(void)


### PR DESCRIPTION
# Prerequisite Checklist

<!--
Please mark items appropriately:
-->

- [x] Read the [contribution guidelines](https://github.com/open-education-hub/ccas-internal/blob/main/CONTRIBUTING.md#pull-requests) regarding submitting new changes to the project;
- [x] Tested your changes against relevant architectures and platforms;
- [x] Updated relevant documentation (if needed).

## Description of changes

The proposed solution for reversePic erroneously passes the height of the image to the ancillary function that swaps rows. Updated to use width instead.
<!--
Please provide a detailed description of the changes made in this new PR.
-->
