### PR TITLE
Replaced python2 with python3 

### DIFF
--- a/labs/lab-10/tasks/overwrite-ret-addr/solution/README.md
+++ b/labs/lab-10/tasks/overwrite-ret-addr/solution/README.md
@@ -33,5 +33,5 @@ size_t i, len;                                  // 16 bytes (8 each one)
 Sum that up and add another 4 for `ebp` => 92
 
 ``` Bash
-python2.7 -c 'print "100\n" + "A" * 92 + "\x96\x85\x04\x08"' > payload
+python3 -c 'import sys; sys.stdout.buffer.write(b"100\n" + b"A" * 92 + b"\x96\x85\x04\x08")' > payload
 ```

--- a/labs/lab-10/tasks/read-stdin-gets/README.md
+++ b/labs/lab-10/tasks/read-stdin-gets/README.md
@@ -47,7 +47,7 @@ This is a string that occupies `8` bytes.
 > For example, to generate a payload that overwrites a value in the code with the value `0xDEADBEEF`, you can execute the following command:
 
 ```python
-python3 -c 'import sys; sys.stdout.buffer.write("A" * 32 + "\xEF\xBE\xAD\xDE")' > payload
+python3 -c 'import sys; sys.stdout.buffer.write(b"A" * 32 + b"\xEF\xBE\xAD\xDE")' > payload
 ```
 
 > **NOTE** number `32` is only an example and it represents the size of buffer that needs to be bypassed.

--- a/labs/lab-10/tasks/read-stdin-gets/README.md
+++ b/labs/lab-10/tasks/read-stdin-gets/README.md
@@ -47,7 +47,7 @@ This is a string that occupies `8` bytes.
 > For example, to generate a payload that overwrites a value in the code with the value `0xDEADBEEF`, you can execute the following command:
 
 ```python
-python2.7 -c 'print "A" * 32 + "\xEF\xBE\xAD\xDE"' > payload
+python3 -c 'import sys; sys.stdout.buffer.write("A" * 32 + "\xEF\xBE\xAD\xDE")' > payload
 ```
 
 > **NOTE** number `32` is only an example and it represents the size of buffer that needs to be bypassed.


### PR DESCRIPTION
# Prerequisite Checklist

<!--
Please mark items appropriately:
-->

- [x] Read the [contribution guidelines](https://github.com/open-education-hub/ccas-internal/blob/main/CONTRIBUTING.md#pull-requests) regarding submitting new changes to the project;
- [x] Tested your changes against relevant architectures and platforms;
- [x] Updated relevant documentation (if needed).

## Description of changes

<!--
Python 2 is no longer available through the official repositories as of Ubuntu 24.04, so the VM will not have python 2. I have updated all occurances of "python" in the labs with their counterpart using "python3". 
-->
