### PR TITLE
labs/lab-04: Fix grumpy-jumps checker and move fibonacci TODO lower

### DIFF
--- a/labs/lab-04/tasks/fibonacci/support/fibonacci.asm
+++ b/labs/lab-04/tasks/fibonacci/support/fibonacci.asm
@@ -11,7 +11,8 @@ section .text
 
 main:
     mov ecx, DWORD [N]       ; we want to find the N-th fibonacci number; N = ECX = 7
-    ; TODO: calculate the N-th fibonacci number (f(0) = 0, f(1) = 1)
     PRINTF32 `%d\n\x0`, ecx  ; DO NOT REMOVE/MODIFY THIS LINE
+
+    ; TODO: calculate the N-th fibonacci number (f(0) = 0, f(1) = 1)
 
     ret

--- a/labs/lab-04/tasks/grumpy-jumps/tests/test.sh
+++ b/labs/lab-04/tasks/grumpy-jumps/tests/test.sh
@@ -16,7 +16,7 @@ mkdir -p "$LOG_DIR"
 FIRST_LINE=$(head -n 1 "$LOG_DIR/result.txt")
 NR_LINES=$(wc -l < "$LOG_DIR/result.txt")
 
-test_display_right()
+test_correct_message()
 {
     if [ "$FIRST_LINE" = "Well done!" ]; then
         exit 0
@@ -25,7 +25,7 @@ test_display_right()
     fi
 }
 
-test_display_only_right()
+test_only_correct_message()
 {
     if [ "$NR_LINES" -eq 1 ]; then
         if [ "$FIRST_LINE" = "Well done!" ]; then


### PR DESCRIPTION
# Prerequisite Checklist

<!--
Please mark items appropriately:
-->

- [x] Read the [contribution guidelines](https://github.com/open-education-hub/ccas-internal/blob/main/CONTRIBUTING.md#pull-requests) regarding submitting new changes to the project;
- [x] Tested your changes against relevant architectures and platforms;
- [x] Updated relevant documentation (if needed).

## Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
- Change the name of grumpy-jumps test functions to match their calls to fix the checker
- Move TODO line lower in fibonacci support to make it more clear for students not to modify the first PRINTF32 in the program
