### PR TITLE
labs/lab-05: Clarify and fix printing in `mul` and `div` task solutions

### DIFF
--- a/labs/lab-05/tasks/div/solution/divide.asm
+++ b/labs/lab-05/tasks/div/solution/divide.asm
@@ -41,7 +41,7 @@ main:
 
     xor ebx, ebx
     mov bx, ax
-    PRINTF32 `Quotient: %hhu\n\x0`, ebx
+    PRINTF32 `Quotient: %hu\n\x0`, ebx
 
     xor ebx, ebx
     mov bx, dx

--- a/labs/lab-05/tasks/mul/solution/multiply.asm
+++ b/labs/lab-05/tasks/mul/solution/multiply.asm
@@ -25,8 +25,9 @@ main:
     mul bl
 
     ; Print result in hexa
-    xor ebx, ebx
-    mov bx, ax
+    ; NOTE: The `%hx` format specifier tells printf to print only the lower half
+    ; (lower 16 bits) of eax - i.e., the ax register - by treating the value as
+    ; a 16-bit unsigned short.
     PRINTF32 `Result is: 0x%hx\n\x0`, eax
 
 
@@ -36,10 +37,8 @@ main:
     mul bx
 
     ; Print result in hexa
-    xor ebx, ebx
-    mov bx, dx
-    xor ebx, ebx
-    mov bx, ax
+    ; NOTE: The `%hx` format specifier is used in the same way as in the
+    ; previous PRINTF32 statement, only now for both dx and ax registers
     PRINTF32 `Result is: 0x%hx%hx\n\x0`, edx, eax
 
 


### PR DESCRIPTION
# Prerequisite Checklist

<!--
Please mark items appropriately:
-->

- [x] Read the [contribution guidelines](https://github.com/open-education-hub/ccas-internal/blob/main/CONTRIBUTING.md#pull-requests) regarding submitting new changes to the project;
- [x] Tested your changes against relevant architectures and platforms;
- [x] Updated relevant documentation (if needed).

## Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
- Remove extraneous instructions used for debugging and clarify the role of `%hx` format specifier in print statements in `mul` solution
- Fix format specifier size of print statement for quotient of 16-bit division in `div` solution
