### PR TITLE
labs/lab-07: Fix README.md and comment for tasks `stack-addressing`, `gcd`

### DIFF
--- a/labs/lab-07/tasks/gcd/README.md
+++ b/labs/lab-07/tasks/gcd/README.md
@@ -12,7 +12,7 @@ The code calculates the greatest common divisor (GCD) of two numbers given as pa
 1. Within the `print` label, display the result in the following format:
 
 ```c
-gcd(49,28) = 7
+gcd(49, 28) = 7
 ```
 
 If you're having difficulties solving this exercise, go through [this](../../reading/stack.md) reading material

--- a/labs/lab-07/tasks/stack-addressing/README.md
+++ b/labs/lab-07/tasks/stack-addressing/README.md
@@ -11,33 +11,32 @@ The `stack-addressing.asm` program in the lab's archive allocates and initialize
 - a string "Bob has corn".
 
 1. Replace each `push` instruction with an equivalent sequence of instructions.
-1. Print the addresses and values on the stack in the interval `[esp, ebp]` (from low addresses to high addresses) byte by byte.
+1. Print the addresses and values on the stack in the interval `[esp, ebp]` (from high addresses to low addresses) dword by dword.
 1. Print the string allocated on the stack byte by byte and explain how it looks in memory.
 Think about where you should start displaying and when you should stop.
 1. Print the vector allocated on the stack element by element.
 Think about where you should start displaying and what size each element has.
 
-> **NOTE:** You should only push 10 elements on the stack.
 After a successful implementation, the program should display something similar to the following output (it won't be exactly the same, stack memory addresses may differ):
 >
 >```c
->0xffcf071b: 65
->0xffcf071c: 110
->0xffcf071d: 97
->0xffcf071e: 32
->0xffcf071f: 97
->0xffcf0734: 4
->0xffcf0735: 0
->0xffcf0736: 0
->0xffcf0737: 0
->0xffcf0738: 5
+>Bob has corn
+>0xffe804cc: 0xf7d91519
+>0xffe804c8: 0x5
+>0xffe804c4: 0x4
+>0xffe804c0: 0x3
+>0xffe804bc: 0x2
+>0xffe804b8: 0x1
+>0xffe804b4: 0x0
+>0xffe804b0: 0x6e726f63
+>0xffe804ac: 0x20736168
+>0xffe804a8: 0x20626f42
 >Bob has corn
 >1 2 3 4 5
 >```
 >
 > Explain the significance of each byte.
 > Why are they arranged in that particular order?
-> Why are some bytes 0?
 >
 > **TIP:** Remember that ASCII character codes are represented as decimal values.
 Remember the order in which the bytes of a larger number are stored: review the section **Order of representation of numbers larger than one byte** from Lab 01.

--- a/labs/lab-07/tasks/stack-addressing/support/stack-addressing.asm
+++ b/labs/lab-07/tasks/stack-addressing/support/stack-addressing.asm
@@ -9,7 +9,7 @@ global main
 main:
     mov ebp, esp
 
-    ; TODO 1: replace every push by an equivalent sequence of commands (use direct addressing of memory. Hint: esp)
+    ; TODO 1: replace every "push" instruction by an equivalent sequence of commands (use direct addressing of memory. Hint: esp)
     mov ecx, NUM
 push_nums:
     push ecx


### PR DESCRIPTION
# Prerequisite Checklist

<!--
Please mark items appropriately:
-->

- [x] Read the [contribution guidelines](https://github.com/open-education-hub/ccas-internal/blob/main/CONTRIBUTING.md#pull-requests) regarding submitting new changes to the project;
- [x] Tested your changes against relevant architectures and platforms;
- [x] Updated relevant documentation (if needed).

## Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
- Surround `push` in TODO 1 comment with quotes in `stack-addressing` such that the checker does not flag it as a false positive use of the `push` instruction in the student's solution
- Fix description and example output in README.md file of the task `stack-addressing` to reflect the behavior expected by the checker (print values in address range from high to low, dword by dword) and remove a few lines related to old example output
- Modify example output in README.md file of the task `gcd` to reflect the output expected by the checker/solution (a space after the comma)
