### PR TITLE
labs/lab-08: Fix a path typo in /tasks/string-print/README.md

### DIFF
--- a/labs/lab-08/tasks/string-print/README.md
+++ b/labs/lab-08/tasks/string-print/README.md
@@ -13,7 +13,7 @@ In the file `print_string.asm`, displaying a string using the `PRINTF32` macro i
 
 Following the example of the `hello_world.asm` file, implement string display using `puts` as well.
 
-If you're having difficulties solving this exercise, take a peek at [hello_world.asm](../../../guides/hello_world/).
+If you're having difficulties solving this exercise, take a peek at [hello_world.asm](../../guides/hello_world/).
 
 To test the implementation, enter the `tests/` directory and run:
 


### PR DESCRIPTION
# Prerequisite Checklist

- [x] Read the [contribution guidelines](https://github.com/open-education-hub/ccas-internal/blob/main/CONTRIBUTING.md#pull-requests) regarding submitting new changes to the project;
- [x] Tested your changes against relevant architectures and platforms;
- [x] Updated relevant documentation (if needed).

## Description of changes

A link in the README file has one "../" too many, leading to a 404 error when clicking on it. This commit fixes this.

