### PR TITLE
labs/lab-09/reading: Fix keyword

### DIFF
--- a/labs/lab-09/reading/memory-layout-c-asm.md
+++ b/labs/lab-09/reading/memory-layout-c-asm.md
@@ -33,7 +33,7 @@ Take the example of calling the `printf()` function from an assembly language pr
 ```Assembly
 global main
 
-external printf
+extern printf
 
 section .data
 


### PR DESCRIPTION
# Prerequisite Checklist

<!--
Please mark items appropriately:
-->

- [x] Read the [contribution guidelines](https://github.com/open-education-hub/ccas-internal/blob/main/CONTRIBUTING.md#pull-requests) regarding submitting new changes to the project;
- [x] Tested your changes against relevant architectures and platforms;
- [x] Updated relevant documentation (if needed).

## Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.

-->

An external function was declared inside a code block using 'external' instead of 'extern', which I've found to be wrong. I switched 'external printf' to 'extern printf'.
