### PR TITLE
workflows/pr-deployment: solved issue regarding inability to render PRs

### DIFF
--- a/.github/workflows/pr-deployment.yml
+++ b/.github/workflows/pr-deployment.yml
@@ -42,8 +42,13 @@ jobs:
         run: |
           mkdir -p ${{ github.event.number }}
           docker image list
-          docker run -v $GITHUB_WORKSPACE/repo:/usr/src/app hardware-software-interface-${{ github.event.number }}:latest
-
+          docker run -v $GITHUB_WORKSPACE/repo:/usr/src/app \
+            hardware-software-interface-${{ github.event.number }}:latest bundle install
+          docker run \
+            -v $GITHUB_WORKSPACE/repo:/usr/src/app \
+            hardware-software-interface-${{ github.event.number }}:latest \
+            jekyll build -d /usr/src/app/_site
+          cp -a $GITHUB_WORKSPACE/repo/_site/. $GITHUB_WORKSPACE/${{ github.event.number }}
       # Popular action to deploy to GitHub Pages:
       # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus
       - name: Deploy to GitHub Pages
@@ -53,6 +58,7 @@ jobs:
           # Build output to publish to the `gh-pages-pr` branch:
           publish_dir: ./${{ github.event.number }}
           destination_dir: ${{ github.event.number }}
+          enable_jekyll: true
           # The following lines assign commit authorship to the official
           # GH-Actions bot for deploys to `gh-pages` branch:
           # https://github.com/actions/checkout/issues/13#issuecomment-724415212

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 source 'https://rubygems.org'
 
+gem 'jekyll'
 gem 'jekyll-titles-from-headings'
 gem 'jekyll-seo-tag'
 gem 'just-the-docs', git: 'https://github.com/just-the-docs/just-the-docs'


### PR DESCRIPTION


# Prerequisite Checklist

- [x] Read the [contribution guidelines](https://github.com/open-education-hub/ccas-internal/blob/main/CONTRIBUTING.md#pull-requests) regarding submitting new changes to the project;
- [x] Tested your changes against relevant architectures and platforms;
- [ ] Updated relevant documentation (if needed).

## Description of changes

- `pr-deployment.yml` modified to properly build using jekyll
and copy the built version into the PR specific folder
- `Gemfile` modified to properly use jekyll
- Settings in the forked repository only include deployment 
from the gh-pages branch

You can find an example of a correctly deployed PR on my fork ('Test' appears at the end of lab 9): https://cartitza.github.io/hardware-software-interface/19/
