### PR TITLE
labs/lab-11: Fix `include-fix` checker

### DIFF
--- a/labs/lab-11/tasks/include-fix/tests/test.sh
+++ b/labs/lab-11/tasks/include-fix/tests/test.sh
@@ -15,7 +15,7 @@ fi
 test_warning() {
     cd "$SRC_PATH" || exit 1
     make clean >/dev/null 2>&1
-    make >make_output.log
+    make >make_output.log 2>&1
     if grep -q "warning" make_output.log; then
         make clean >/dev/null 2>&1
         rm make_output.log


### PR DESCRIPTION


# Prerequisite Checklist

<!--
Please mark items appropriately:
-->

- [x] Read the [contribution guidelines](https://github.com/cs-pub-ro/hardware-software-interface/blob/main/CONTRIBUTING.md#pull-requests) regarding submitting new changes to the project;
- [x] Tested your changes against relevant architectures and platforms;
- [x] Updated relevant documentation (if needed).

## Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
- Add a redirect from stderr to stdout in checker, such that the checker can find the warning in the output and not award the points if the warning is present.