### PR TITLE
labs/lab-05: Fix correct awk field index for sum_n_squares parsing

### DIFF
--- a/labs/lab-05/tasks/sum-squared/tests/test.sh
+++ b/labs/lab-05/tasks/sum-squared/tests/test.sh
@@ -16,7 +16,7 @@ else
 fi
 
 sum=$(echo "$OUTPUT1" | grep "Sum" | awk '{print $2}' | tr -d '():')
-sum_squares=$(echo "$OUTPUT2" | grep "Sum" | awk '{print $4}' | tr -d '():')
+sum_squares=$(echo "$OUTPUT2" | grep "Sum" | awk '{print $2}' | tr -d '():')
 
 test_sum() {
 	if [[ -z $sum ]]; then


### PR DESCRIPTION
The current implementation uses awk '{print $4}' which fails
to capture the correct value (given the example in sum_n.asm).

The `sum_n` binary uses the following format:
`PRINTF64 "Sum(%lu): %lu\n\x0", rcx, rax`

Because of this, the result value is the second space separated field (`$2`). 
The current script was incorrectly looking at the fourth field (`$4`).