### PR TITLE
Lab9/max-c-calls-x86: Actually compile in 32-bit mode

### DIFF
--- a/labs/lab-09/tasks/max-c-calls-x86/support/Makefile
+++ b/labs/lab-09/tasks/max-c-calls-x86/support/Makefile
@@ -1,6 +1,7 @@
-CFLAGS = -Wall -g
+CFLAGS = -Wall -g -m32
 ASM = nasm
-ASMFLAGS = -f elf64 -F dwarf
+ASMFLAGS = -f elf32
+LDFLAGS = -no-pie
 
 .DEFAULT_GOAL: all
 
@@ -9,12 +10,13 @@ ASMFLAGS = -f elf64 -F dwarf
 all: main
 
 main: main.o max.o
-	$(CC) $(LDFLAGS) -o $@ $^
+	$(CC) -m32 $(LDFLAGS) -o $@ $^
+
+main.o: main.c
+	$(CC) $(CFLAGS) -c -o $@ $<
 
 max.o: max.asm
 	$(ASM) $(ASMFLAGS) -o $@ $<
-
-main.o: main.c
 
 clean:
 	-rm -f main *.o


### PR DESCRIPTION
The current Makefile invokes the assembler and compiler in 64-bit mode, which causes some errors in max.asm. This patch fixes these issues by essentially copying the flags from the 'max-assembly-calls-x86' task.

# Prerequisite Checklist
- [x] Read the [contribution guidelines](https://github.com/open-education-hub/ccas-internal/blob/main/CONTRIBUTING.md#pull-requests) regarding submitting new changes to the project;
- [x] Tested your changes against relevant architectures and platforms;

## Description of changes
Changed the assembler/compiler flags to target 32-bit.
