### PR TITLE
Fix lab 10 segmentation fault in tasks

### DIFF
--- a/labs/lab-10/tasks/read-stdin-fgets/support/read_stdin_fgets.asm
+++ b/labs/lab-10/tasks/read-stdin-fgets/support/read_stdin_fgets.asm
@@ -81,7 +81,7 @@ print_byte:
     add rsp, 8                  ; restore stack
     pop rcx                     ; restore rcx
     inc rcx
-    cmp rcx, [rbp - 80]
+    cmp rcx, [rbp - 88]
     jl print_byte
 
     ; Final puts

--- a/labs/lab-10/tasks/read-stdin-gets/support/read_stdin.asm
+++ b/labs/lab-10/tasks/read-stdin-gets/support/read_stdin.asm
@@ -76,7 +76,7 @@ print_byte:
     pop rcx     ; restore rcx
 
     inc rcx
-    cmp rcx, [rbp - 80]
+    cmp rcx, [rbp - 88]
     jl print_byte
 
     mov rdi, null_string


### PR DESCRIPTION
# Prerequisite Checklist

- [x] Read the [contribution guidelines](https://github.com/open-education-hub/ccas-internal/blob/main/CONTRIBUTING.md#pull-requests) regarding submitting new changes to the project;
- [x] Tested your changes against relevant architectures and platforms;
- [x] Updated relevant documentation (if needed).

## Description of changes

Previously, running the executables for the `read-stdin-gets` and `read-stdin-fgets` tasks would result in the `print_byte` loop running indefinitely, resulting in a segmentation fault. This happened because the limit for the iterator was read from the wrong address (or due to stack alignments made by the user).

The fix I provided changes the address from which the limit is read, such that the program no longer crashes.